### PR TITLE
Feature/#24 validate get business week

### DIFF
--- a/src/AbstractAdapter.php
+++ b/src/AbstractAdapter.php
@@ -126,7 +126,7 @@ abstract class AbstractAdapter
      *
      * @throws ConfigException
      */
-    public function setFyWeeks($fiftyThreeWeeks = false): void
+    public function setFyWeeks(bool $fiftyThreeWeeks = false): void
     {
         if (!$this->isBusinessType($this->type)) {
             $this->throwConfigurationException(
@@ -134,11 +134,7 @@ abstract class AbstractAdapter
             );
         }
 
-        $this->fyWeeks = 53;
-
-        if (!$fiftyThreeWeeks) {
-            $this->fyWeeks = 52;
-        }
+        $this->fyWeeks = $fiftyThreeWeeks ? 53 : 52;
     }
 
     /**

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -46,7 +46,7 @@ interface AdapterInterface
      *
      * @throws ConfigException
      */
-    public function setFyWeeks($fiftyThreeWeeks = false): void;
+    public function setFyWeeks(bool $fiftyThreeWeeks = false): void;
 
     /**
      * Get the financial year start date.

--- a/src/DateTimeAdapter.php
+++ b/src/DateTimeAdapter.php
@@ -58,7 +58,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
      *
      * @throws Exception
      */
-    public function setFyWeeks($fiftyThreeWeeks = false): void
+    public function setFyWeeks(bool $fiftyThreeWeeks = false): void
     {
         $originalFyWeeks = $this->fyWeeks;
 

--- a/src/DateTimeAdapter.php
+++ b/src/DateTimeAdapter.php
@@ -118,7 +118,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
      * {@inheritdoc}
      *
      * First check for calendar type and the return the corresponding value.
-     * Otherwise it is business type as the only other available.
+     * Otherwise, it is business type as the only other available.
      *
      * @return DatePeriod|DateTimeImmutable[]
      *
@@ -186,10 +186,13 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
     {
         $dateTime = $this->getDateObject($date);
 
+        if (!$this->isBusinessType($this->getType())) {
+            throw new ConfigException('Business weeks are set only for a business type financial year.');
+        }
+
         $this->validateDateBelongsToCurrentFinancialYear($dateTime);
 
         for ($id = 1; $id <= $this->fyWeeks; $id++) {
-
             if (
                 $dateTime >= $this->getFirstDateOfBusinessWeekById($id) &&
                 $dateTime <= $this->getLastDateOfBusinessWeekById($id)

--- a/tests/Unit/DateTimeAdapterTest.php
+++ b/tests/Unit/DateTimeAdapterTest.php
@@ -597,6 +597,30 @@ class DateTimeAdapterTest extends BaseTestCase
      * @throws Exception
      * @throws \Exception
      */
+    public function assertGetBusinessWeekIdByDateThrowsExceptionOnNonBusinessTypeFinancialYear(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Business weeks are set only for a business type financial year.');
+
+        // Financial Year starts at 2019-01-01
+        $dateTimeAdapter = new DateTimeAdapter(
+            AbstractAdapter::TYPE_CALENDAR,
+            '2019-01-01',
+            (bool) random_int(0, 1)
+        );
+
+        $dateTimeAdapter->getBusinessWeekIdIdByDate('2019-01-04');
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws ConfigException
+     * @throws Exception
+     * @throws \Exception
+     */
     public function assertGetBusinessWeekIdByDateThrowsExceptionOnDateBeforeFinancialYear(): void
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Closes #24 as it adds validation that the method can only be used if financial year is set to `business` type.
The concept of `financial weeks is valid for `business` type financial year only.