### PR TITLE
Feature/#6 timezone param for string datetime

### DIFF
--- a/.docker/Dockerfile.example
+++ b/.docker/Dockerfile.example
@@ -16,6 +16,10 @@ RUN apt update && \
     zip \
     unzip
 
+# Install Packages via PECL as not provided by PHP Source
+RUN pecl install xdebug \
+	&& docker-php-ext-enable xdebug
+
 # Clear cache
 RUN apt clean && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ so you might need to copy the `phpunit.xml.dist` file to `phpunit.xml` and make 
 XDEBUG_MODE=coverage ./vendor/phpunit/phpunit/phpunit
 ```
 
+
+```shell
+# HTML coverage example
+XDEBUG_MODE=coverage ./vendor/phpunit/phpunit/phpunit --coverage-html tests/report
+```
+
 ### Run Static Analysis
 The library uses PHPStan as a static analysis tool with the default level set to 5.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ $fy = new \RoussKS\FinancialYear\DateTimeAdapter('calendar', $startDate);
 echo $fy->getFyEndDate()->format('Y-m-d'); // 2019-12-31 
 ```
 
+### Docker images
+The library provides a sample Dockerfile to assist in development use if you want to contribute.
+This using the official php cli images.
+Copy the `Dockerfile.example` file to Dockerfile, uncommenting the required php version.
+
+However, you are free to use any methodology you want for developing updates & bugfixes.
+
+### Run Tests
+The library has an extensive test suite to cover most scenarios & negative paths.
+
+Be aware that some configurations for phpunit are different between versions, 
+so you might need to copy the `phpunit.xml.dist` file to `phpunit.xml` and make the necessary adjustments.
+
+```shell
+./vendor/phpunit/phpunit/phpunit
+```
+
+```shell
+XDEBUG_MODE=coverage ./vendor/phpunit/phpunit/phpunit
+```
+
+### Run Static Analysis
+The library uses PHPStan as a static analysis tool with the default level set to 5.
+
+```shell
+./vendor/bin/phpstan analyse
+```
+
 ### Limitations
 Unfortunately, the library does not support a start date of 29, 30, 31 of any month for *`calendar`* financial year type.
 
@@ -62,7 +90,7 @@ e.g. if a year starts on 31/1, does the first period end on 28/2? And the follow
 
 If upon library usage, a user has encountered such a real business issue and can provide a mitigation logic, we can work on implementing it. 
 
-_Important_: This is allowed for a *`business`* type financial year. 
+_Important_: This is allowed for a *`business`* type financial year.
 
 ### Future Plans
 - Update Readme or create Wiki page with more examples of all available methods.

--- a/src/AbstractAdapter.php
+++ b/src/AbstractAdapter.php
@@ -128,7 +128,7 @@ abstract class AbstractAdapter
      */
     public function setFyWeeks(bool $fiftyThreeWeeks = false): void
     {
-        if (!$this->isBusinessType($this->type)) {
+        if (!$this->isBusinessType($this->getType())) {
             $this->throwConfigurationException(
                 'Can not set the financial year weeks property for non business year type.'
             );
@@ -163,7 +163,7 @@ abstract class AbstractAdapter
      */
     protected function validatePeriodId(int $id): void
     {
-        if ($id < 1 || $id > $this->fyPeriods) {
+        if ($id < 1 || $id > $this->getFyPeriods()) {
             throw new Exception('There is no period with id: ' . $id . '.');
         }
     }
@@ -180,11 +180,11 @@ abstract class AbstractAdapter
      */
     protected function validateBusinessWeekId(int $id): void
     {
-        if (!$this->isBusinessType($this->type)) {
+        if (!$this->isBusinessType($this->getType())) {
             $this->throwConfigurationException('Week id is not applicable for non business type financial year.');
         }
 
-        if ($id < 1 || $id > $this->fyWeeks) {
+        if ($id < 1 || $id > $this->getFyWeeks()) {
             throw new Exception('There is no week with id: ' . $id . '.');
         }
     }

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -70,7 +70,7 @@ interface AdapterInterface
     public function setFyStartDate($date): void;
 
     /**
-     * Get the financial year end date.
+     * Get the financial year's end date.
      *
      * @return DateTimeInterface
      */

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -61,8 +61,6 @@ interface AdapterInterface
      * Expects either string ISO-8601 format 'YYYY-MM-DD'
      * or a date object, same object instance as the adapter's that extends the DateTimeInterface
      *
-     * Throws an exception if FyEndDate is already set.
-     *
      * @param  string|DateTimeInterface $date
      *
      * @return void

--- a/src/DateTimeAdapter.php
+++ b/src/DateTimeAdapter.php
@@ -7,6 +7,7 @@ use DatePeriod;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use RoussKS\FinancialYear\Exceptions\ConfigException;
 use RoussKS\FinancialYear\Exceptions\Exception;
 use Traversable;
@@ -31,21 +32,29 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
     protected $fyEndDate;
 
     /**
+     * @var DateTimeZone|null
+     */
+    private $dateTimeZone;
+
+    /**
      * DateTimeAdapter constructor.
      *
-     * @param  string $fyType
-     * @param  DateTime|DateTimeImmutable|DateTimeInterface|string $fyStartDate, string must be of ISO-8601 format 'YYYY-MM-DD'
-     * @param  bool $fiftyThreeWeeks
+     * @param string $fyType
+     * @param DateTime|DateTimeImmutable|DateTimeInterface|string $fyStartDate // string must be of ISO-8601 format 'YYYY-MM-DD'
+     * @param bool $fiftyThreeWeeks
+     * @param DateTimeZone|string|null $dateTimeZone // this will be used only and only if a string was provided for start date
      *
      * @return void
      *
-     * @throws Exception
      * @throws ConfigException
+     * @throws Exception
      */
-    public function __construct(string $fyType, $fyStartDate, bool $fiftyThreeWeeks = false)
+    public function __construct(string $fyType, $fyStartDate, bool $fiftyThreeWeeks = false, $dateTimeZone = null)
     {
         parent::__construct($fyType, $fiftyThreeWeeks);
 
+        // First set the timezone, then the start date and then auto calculate the end date of the financial year.
+        $this->setDateTimeZone($dateTimeZone);
         $this->setFyStartDate($fyStartDate);
 
         $this->autoSetFyEndDateByStartDate();
@@ -224,17 +233,17 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         // If 1st period, get the start of the financial year, regardless of the type.
         if ($id === 1) {
-            return $this->fyStartDate;
+            return $this->getFyStartDate();
         }
 
         // In calendar type, fyPeriods are always 12 as the months,
         // regardless of the start date within the month.
-        if ($this->isCalendarType($this->type)) {
-            return $this->fyStartDate->modify('+' . ($id - 1) . ' months');
+        if ($this->isCalendarType($this->getType())) {
+            return $this->getFyStartDate()->modify('+' . ($id - 1) . ' months');
         }
 
         // Otherwise return business type calculation.
-        return $this->fyStartDate->modify('+' . ($id - 1) * 4 . ' weeks');
+        return $this->getFyStartDate()->modify('+' . ($id - 1) * 4 . ' weeks');
     }
 
     /**
@@ -255,18 +264,18 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         // If last period, get the end of the financial year, regardless of the type.
         if ($id === $this->fyPeriods) {
-            return $this->fyEndDate;
+            return $this->getFyEndDate();
         }
 
         // In calendar type, fyPeriods are always 12 as the months,
         // regardless of the start date within the month.
-        if ($this->isCalendarType($this->type)) {
+        if ($this->isCalendarType($this->getType())) {
             // Otherwise calculate for business type.
-            return $this->fyStartDate->modify('+' . $id . ' months')->modify('-1 day');
+            return $this->getFyStartDate()->modify('+' . $id . ' months')->modify('-1 day');
         }
 
         // Otherwise calculate for business type.
-        return $this->fyStartDate->modify('+' . $id * 4 . ' weeks')->modify('-1 day');
+        return $this->getFyStartDate()->modify('+' . $id * 4 . ' weeks')->modify('-1 day');
     }
 
     /**
@@ -284,10 +293,10 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         // If 1st week, get the start of the financial year.
         if ($id === 1) {
-            return $this->fyStartDate;
+            return $this->getFyStartDate();
         }
 
-        return $this->fyStartDate->modify('+' . ($id - 1) . ' weeks');
+        return $this->getFyStartDate()->modify('+' . ($id - 1) . ' weeks');
     }
 
     /**
@@ -305,10 +314,10 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         // If last week, get the end of the financial year.
         if ($id === $this->fyWeeks) {
-            return $this->fyEndDate;
+            return $this->getFyEndDate();
         }
 
-        return $this->fyStartDate->modify('+' . $id . ' weeks')->modify('-1 day');
+        return $this->getFyStartDate()->modify('+' . $id . ' weeks')->modify('-1 day');
     }
 
     /**
@@ -383,13 +392,13 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
     public function getNextFyStartDate(): DateTimeInterface
     {
         // For calendar type, the next year's start date is + 1 year.
-        if ($this->isCalendarType($this->type)) {
-            return $this->fyStartDate->modify('+1 year');
+        if ($this->isCalendarType($this->getType())) {
+            return $this->getFyStartDate()->modify('+1 year');
         }
 
         // For business type, the next year's start date is + number of weeks.
         // As a financial year would have 52 or 53 weeks, the param handles it.
-        return $this->fyStartDate->modify('+' . $this->fyWeeks . ' weeks');
+        return $this->getFyStartDate()->modify('+' . $this->fyWeeks . ' weeks');
     }
 
     /**
@@ -404,8 +413,8 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
         $disallowedFyCalendarTypeDates = ['29', '30', '31'];
 
         if (
-            $this->isCalendarType($this->type) &&
-            in_array($this->fyStartDate->format('d'), $disallowedFyCalendarTypeDates, true)
+            $this->isCalendarType($this->getType()) &&
+            in_array($this->getFyStartDate()->format('d'), $disallowedFyCalendarTypeDates, true)
         ) {
             $this->throwConfigurationException(
                 'This library does not support 29, 30, 31 as start dates of a month for calendar type financial year.'
@@ -424,7 +433,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
      */
     protected function validateDateBelongsToCurrentFinancialYear(DateTimeImmutable $dateTime): void
     {
-        if ($dateTime < $this->fyStartDate || $dateTime > $this->fyEndDate) {
+        if ($dateTime < $this->getFyStartDate() || $dateTime > $this->getFyEndDate()) {
             throw new Exception('The requested date is out of range of the current financial year.');
         }
     }
@@ -441,6 +450,44 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
     protected function autoSetFyEndDateByStartDate(): void
     {
         $this->fyEndDate = $this->getNextFyStartDate()->modify('-1 day');
+    }
+
+    /**
+     * Get the DateTimeZone currently set
+     *
+     * @return DateTimeZone|null
+     */
+    protected function getDateTimeZone(): ?DateTimeZone
+    {
+        return $this->dateTimeZone;
+    }
+
+    /**
+     * @param DateTimeZone|string|null $dateTimeZone
+     * @return void
+     * @throws ConfigException
+     */
+    protected function setDateTimeZone($dateTimeZone = null): void
+    {
+        if ($dateTimeZone === null) {
+            return;
+        }
+
+        if ($dateTimeZone instanceof DateTimeZone) {
+            $this->dateTimeZone = $dateTimeZone;
+            return;
+        }
+
+        if (is_string($dateTimeZone)) {
+            try {
+                $this->dateTimeZone = new DateTimeZone($dateTimeZone);
+            } catch (\Exception $ex) {
+                // Catch exception, set null timezone string and throw config exception.
+                $this->throwConfigurationException('Invalid dateTimeZone string: ' . $dateTimeZone);
+            }
+        }
+
+        $this->throwConfigurationException('Invalid dateTimeZone parameter');
     }
 
     /**
@@ -495,6 +542,6 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
             return $date;
         }
 
-        return DateTimeImmutable::createFromFormat('Y-m-d', $date);
+        return DateTimeImmutable::createFromFormat('Y-m-d', $date, $this->getDateTimeZone());
     }
 }

--- a/src/DateTimeAdapter.php
+++ b/src/DateTimeAdapter.php
@@ -48,7 +48,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         $this->setFyStartDate($fyStartDate);
 
-        $this->setFyEndDate();
+        $this->autoSetFyEndDateByStartDate();
     }
 
     /**
@@ -66,7 +66,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         // Reset the financial year's end date according to the weeks setting.
         if ($originalFyWeeks !== null && $originalFyWeeks !== $this->fyWeeks) {
-            $this->setFyEndDate();
+            $this->autoSetFyEndDateByStartDate();
         }
     }
 
@@ -96,11 +96,11 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
 
         $this->validateStartDate();
 
-        // If this method was not called on instantiation,
+        // If this method execution is not triggered on instantiation (constructor) which performs the same action,
         // recalculate financial year's end date from current settings,
         // even if the new start date is the same as the previous one (why re-setting the same date?).
         if ($originalFyStartDate !== null) {
-            $this->setFyEndDate();
+            $this->autoSetFyEndDateByStartDate();
         }
     }
 
@@ -430,7 +430,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-     * Set the financial year end date.
+     * Automatically set the financial year's end date by the current start date.
      *
      * We will set end date from the start date object which should be present.
      * Both types calculate end date relative to next financial year start date.
@@ -438,7 +438,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
      *
      * @return void
      */
-    protected function setFyEndDate(): void
+    protected function autoSetFyEndDateByStartDate(): void
     {
         $this->fyEndDate = $this->getNextFyStartDate()->modify('-1 day');
     }

--- a/src/DateTimeAdapter.php
+++ b/src/DateTimeAdapter.php
@@ -481,6 +481,7 @@ class DateTimeAdapter extends AbstractAdapter implements AdapterInterface
         if (is_string($dateTimeZone)) {
             try {
                 $this->dateTimeZone = new DateTimeZone($dateTimeZone);
+                return;
             } catch (\Exception $ex) {
                 // Catch exception, set null timezone string and throw config exception.
                 $this->throwConfigurationException('Invalid dateTimeZone string: ' . $dateTimeZone);

--- a/tests/Unit/DateTimeAdapterTest.php
+++ b/tests/Unit/DateTimeAdapterTest.php
@@ -5,6 +5,7 @@ namespace RoussKS\FinancialYear\Tests\Unit;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use RoussKS\FinancialYear\AbstractAdapter;
 use RoussKS\FinancialYear\DateTimeAdapter;
 use RoussKS\FinancialYear\Exceptions\ConfigException;
@@ -159,6 +160,140 @@ class DateTimeAdapterTest extends BaseTestCase
             $originalFyStartDate->format('YmdHis'),
             $dateTimeAdapter->getFyEndDate()->format('YmdHis')
         );
+    }
+
+    /**
+     * Assert DateTimeZone param is ignored if:
+     * - fyStartDate param is a DateTime instance
+     * - dateTimeZone param is provided.
+     *
+     * @test
+     *
+     * @return void
+     *
+     * @throws Exception
+     * @throws ConfigException
+     * @throws \Exception
+     */
+    public function assertSetFyStartDateIgnoresDateTimeZoneParamIfStartDateParamIsDateTimeInstance(): void
+    {
+        $type = $this->fyTypes[array_rand($this->fyTypes)];
+
+        $defaultTimeZone = new DateTimeZone('UTC');
+        $timeZone = new DateTimeZone('Europe/Athens');
+
+        $dateTimeAdapter = new DateTimeAdapter(
+            $type,
+            $type === 'business'
+                ? $this->getRandomDateTime()->setTimezone($defaultTimeZone) // @phpstan-ignore-line
+                : $this->getRandomDateExcludingDisallowedFyCalendarTypeDates()->setTimezone($defaultTimeZone),
+            (bool) random_int(0, 1),
+            $timeZone
+        );
+
+        $this->assertNotSame($timeZone->getName(), $dateTimeAdapter->getFyStartDate()->getTimezone()->getName());
+    }
+
+    /**
+     * Assert Start Date timezone is set correctly if:
+     * - fyStartDate param is a string
+     * - dateTimeZone param is provided and is DateTimeZone instance.
+     *
+     * @test
+     *
+     * @return void
+     *
+     * @throws Exception
+     * @throws ConfigException
+     * @throws \Exception
+     */
+    public function assertSetFyStartDateSetsCorrectTimeZoneIfStartDateIsStringAndDateTimeZoneInstance(): void
+    {
+        $type = $this->fyTypes[array_rand($this->fyTypes)];
+
+        $timeZone = new DateTimeZone('Europe/Athens');
+
+        $dateTimeAdapter = new DateTimeAdapter($type, '2023-11-19', (bool) random_int(0, 1), $timeZone);
+
+        $this->assertSame($timeZone->getName(), $dateTimeAdapter->getFyStartDate()->getTimezone()->getName());
+    }
+
+    /**
+     * Assert Start Date timezone is set correctly if:
+     * - fyStartDate param is a string
+     * - dateTimeZone param is provided and is a string of available DateTimeZones.
+     *
+     * @test
+     *
+     * @return void
+     *
+     * @throws Exception
+     * @throws ConfigException
+     * @throws \Exception
+     */
+    public function assertSetFyStartDateSetsCorrectTimeZoneIfStartDateIsStringAndDateTimeZoneString(): void
+    {
+        $type = $this->fyTypes[array_rand($this->fyTypes)];
+
+        $timeZone = 'Europe/Athens';
+
+        $dateTimeAdapter = new DateTimeAdapter($type, '2023-11-19', (bool) random_int(0, 1), $timeZone);
+
+        $this->assertSame($timeZone, $dateTimeAdapter->getFyStartDate()->getTimezone()->getName());
+    }
+
+    /**
+     * Assert an exception is thrown on setting FY Start Date if:
+     * - dateTimeZone param is provided and is a string of available DateTimeZones.
+     *
+     * @test
+     *
+     * @return void
+     *
+     * @throws Exception
+     * @throws ConfigException
+     * @throws \Exception
+     */
+    public function assertSetFyStartDateThrowsExceptionIfInvalidDateTimeZoneStringIsProvided(): void
+    {
+        $type = $this->fyTypes[array_rand($this->fyTypes)];
+
+        $timeZone = 'Random TimeZone';
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Invalid dateTimeZone string: ' . $timeZone);
+
+        new DateTimeAdapter($type, '2023-11-19', (bool) random_int(0, 1), $timeZone);
+    }
+
+    /**
+     * Assert an exception is thrown on setting FY Start Date if:
+     * - dateTimeZone param is provided and is of an unsupported type.
+     *
+     * @test
+     *
+     * @return void
+     *
+     * @throws Exception
+     * @throws ConfigException
+     * @throws \Exception
+     */
+    public function assertSetFyStartDateThrowsExceptionIfInvalidDateTimeZoneTypeIsProvided(): void
+    {
+        $type = $this->fyTypes[array_rand($this->fyTypes)];
+
+        $timeZoneTypes = [
+            new \stdClass(),
+            ['something-1', 'something-2'],
+            random_int(1, 100),
+            (bool) random_int(0, 1)
+        ];
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Invalid dateTimeZone parameter');
+
+        // @phpstan-ignore-next-line
+        new DateTimeAdapter($type, '2023-11-19', (bool) random_int(0, 1), $timeZoneTypes[array_rand($timeZoneTypes)]);
     }
 
     /**


### PR DESCRIPTION
Closes #6 

- Allows setting the timezone param on class instantiation of `DateTimeAdapter`
- Allows either a string or a `DateTimeZone` instance
- Added tests