### PR TITLE
#34 minimum php version

### DIFF
--- a/.docker/Dockerfile.example
+++ b/.docker/Dockerfile.example
@@ -1,11 +1,7 @@
 # Uncomment the php version that you want to test.
-# FROM php:7.1-cli
-# FROM php:7.2-cli
-# FROM php:7.3-cli
-# FROM php:7.4-cli
-# FROM php:8.0-cli
 # FROM php:8.1-cli
 # FROM php:8.2-cli
+# FROM php:8.3-cli
 
 # Install dependencies
 RUN apt update && \

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,17 +26,18 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
+          coverage: none
           tools: composer, phpstan
       - name: "Get composer cache directory"
         id: composer-cache
-        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: "Cache dependencies"
         uses: actions/cache@v4
         with:
-          path: "${{ steps.composer-cache.outputs.dir }}"
-          key: "${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}"
-          restore-keys: "${{ runner.os }}-php-${{ matrix.php}}-composer-"
-      - name: "Install Composer dependencies"
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php}}-composer-
+      - name: "Install Dependencies via Composer"
         run: composer install --no-ansi --prefer-dist
       - name: "Run PHPStan Static Analysis"
         run: phpstan analyse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,25 @@ jobs:
       matrix:
         php: [8.1, 8.2, 8.3]
     steps:
-      - name: 'Checkout Code'
+      - name: "Checkout Code"
         uses: actions/checkout@v4
-      - name: 'Setup PHP'
+      - name: "Setup PHP"
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-      - name: Update composer to v2
-        run: composer self-update --2
-      - name: Install Dependencies via Composer
-        run: composer install --no-ansi --no-interaction --no-progress --no-scripts --prefer-dist
-      - name: Run PHPUnit
+          coverage: none
+          tools: composer, phpunit
+      - name: "Get composer cache directory"
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: "Cache dependencies"
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php}}-composer-
+      - name: "Install Dependencies via Composer"
+        run: composer install --no-ansi --prefer-dist
+      - name: "Run PHPUnit"
         run: ./vendor/bin/phpunit
-#        run: ./vendor/bin/phpunit --coverage-clover=coverage.xml - Add when coverage is fixed
 # ToDo: Add Code Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docker-compose.yml
 /tests/report/
 clover.xml
 phpunit.xml
+/.phpunit.cache/
 .phpunit.result.cache
 
 # IDE & System

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11"
+        "phpunit/phpunit": "^10 || ^11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^7 || ^8 || ^9 || ^10"
+        "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
+          <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <logging />
+    <source>
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-    </logging>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
Closes #34 

- Updates composer requirements to minimum PHP `8.1`
- Updates phpunit to support the relevant versions
- Removed non-supported php versions from relevalt local develoment docker files
- Updated github action to use `shivammathur/setup-php` tools